### PR TITLE
Dockerfile: Disable workspace mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
 
 ENV GO111MODULE=on
+ENV GOWORK=off
 ENV GOFLAGS=-mod=vendor
 
 # copy just enough of the git repo to parse HEAD, used to record version in OLM binaries


### PR DESCRIPTION
Update the Dockerfile and set the GOWORK environment variable to "false"
to disable workspace mode, which is producing o/release CI failures.

Signed-off-by: timflannagan <timflannagan@gmail.com>